### PR TITLE
Added in-game-start and in-game-end to the session summary files

### DIFF
--- a/sessions/session-10-summary.md
+++ b/sessions/session-10-summary.md
@@ -2,6 +2,8 @@
 title: Session 10 Summary
 description: A description of the in-game events that happened during Session 10 of the In Dire Straits campaign.
 date: 2025-04-12
+in-game-start: 7922-008 15:30
+in-game-end: 7922-008 22:20
 ---
 
 The Dire Straits, crewed only by Jithal, Chris, and Steve Irwin, traveled to the outer system to finally track down location of the possible new strait point, and stake their claim by shooting it to the unknown system on the other side.

--- a/sessions/session-5-summary.md
+++ b/sessions/session-5-summary.md
@@ -1,6 +1,8 @@
 ---
 title: Session 5 Summary 
 date: 2024-12-21
+in-game-start: 7922-007 28:40
+in-game-end: 7922-008 01:25
 ---
 
 After the *Jitterbug* and the *Dire Straits* rendezvoused outside the sensor range of Zerzi planet’s defence network, Captain Delano Mack left in the *Jitterbug* on his way to Cuthbert Station as he agreed to during the rendezvous.

--- a/sessions/session-6-summary.md
+++ b/sessions/session-6-summary.md
@@ -1,6 +1,8 @@
 ---
 title: Session 6 Summary
 date: 2025-01-04
+in-game-start: 7922-008 01:25
+in-game-end: 7922-008 07:45
 ---
 
 The *Dire Straits* was heading out from Zerzi Station toward Cuthbert, a 4 hour journey. Their Tatternet feed included a

--- a/sessions/session-7-summary.md
+++ b/sessions/session-7-summary.md
@@ -1,6 +1,8 @@
 ---
 title: Session 7 Summary
 date: 2025-02-01
+in-game-start: 7922-008 07:45
+in-game-end: 7922-008 08:30
 ---
 
 ## Delano, prior to Session 7 (Session 6a)

--- a/sessions/session-8-summary.md
+++ b/sessions/session-8-summary.md
@@ -1,6 +1,8 @@
 ---
 title: Session 8 Summary
 date: 2025-02-15
+in-game-start: 7922-008 08:30
+in-game-end: 7922-008 08:45
 ---
 
 ![](/images/Molgri.jpg){align="right"  caption="Ramekin Finch's pet Molgri, Malky."}

--- a/sessions/session-9-summary.md
+++ b/sessions/session-9-summary.md
@@ -1,6 +1,8 @@
 ---
 title: Session 9 Summary
 date: 2025-03-29
+in-game-start: 7922-008 08:45
+in-game-end: 7922-008 09:30
 ---
 
 The crew defeated Pirate Queen Ramekin Finch, for now, and escaped from her asteroid base, rescuing the survivors of the
@@ -14,5 +16,3 @@ and will deal with that as he can.
 The Dire Straits leaves the station ahead of the mob of press and paparazzi. Delano Mack becomes the face of the
 Siouxiana rescue, while Jim Dade disappears in the crowd. Delano will be trying to get Elizabeth Catlow down to Zerzi
 City to talk to Bar Eewit about the data on her stick.
-
-*Last Session End Game Time: 7922-008 09:30*


### PR DESCRIPTION

Will need to update some configuration in the cluster-map repo so we can use this data in the code.